### PR TITLE
No strict vars for one-liners

### DIFF
--- a/lib/perl5i/2.pm
+++ b/lib/perl5i/2.pm
@@ -48,12 +48,20 @@ sub import {
     mro::set_mro( $caller, 'c3' );
 
     load_in_caller( $caller => (
-        ["CLASS"], ["File::chdir"],
-        [English => qw(-no_match_vars)],
-        ["Want" => qw(want)], ["Try::Tiny"], ["Perl6::Caller"], ["Carp"],
+        ['CLASS'],
+        ['File::chdir'],
+        ['English' => qw(-no_match_vars)],
+        ['Want' => qw(want)],
+        ['Try::Tiny'],
+        ['Perl6::Caller'],
+        ['Carp'],
         ['perl5i::2::Signatures'],
         ['Child' => qw(child)],
     ) );
+    # no strict vars for oneliners - GH #63
+    strict::unimport($class, 'vars')
+        if $class eq 'perl5i::cmd'
+        or $0 eq '-e';
 
     # Have to call both or it won't work.
     true::import($class);

--- a/t/command_line_wrapper.t
+++ b/t/command_line_wrapper.t
@@ -59,4 +59,9 @@ is capture { system @perl5icmd, "-e", q[print __FILE__] }, "-e",       '__FILE__
     is `$perl5icmd $file`, "Hello\n", "program in a file";
 }
 
+# Check it doesn't have strict vars on
+is capture {system @perl5icmd, '-e', q($fun="yay"; say $fun;)}, "yay\n", 'no strict vars for perl5i';
+is capture {system ($^X, '-Ilib', '-Mperl5i::latest', '-e', q|$fun="yay"; say $fun;|)},
+    "yay\n", q{no strict vars for perl -Mperl5i::latest -e '...'};
+
 done_testing;


### PR DESCRIPTION
This disables strict vars for one-liners using the perl5i executable, or when perl5i is loaded manually:

```
perl -Mperl5i::latest -e '$fun="yay"; say $fun;'
```

Fixes #63
