### PR TITLE
support for "use perl5i version => 2"

### DIFF
--- a/lib/perl5i/VERSION.pm
+++ b/lib/perl5i/VERSION.pm
@@ -7,6 +7,7 @@ use warnings;
 
 use version 0.77; our $VERSION = qv("v2.6.1");
 
-sub latest { "perl5i::2" };     # LATEST HERE (for automated update)
+sub latest_version { 2 } # LATEST HERE (for automated update)
+sub latest { 'perl5i::' . __PACKAGE__->latest_version }
 
 1;

--- a/t/perl5i_alternate.t
+++ b/t/perl5i_alternate.t
@@ -1,0 +1,9 @@
+#!/usr/bin/env perl
+
+use Test::More;
+
+# using perl5i with a specific version is ok
+eval "use perl5i version => 2";
+ok !$@, "use perl5i version => ...";
+
+done_testing();


### PR DESCRIPTION
This is a proposal for an alternative on how to specify the perl5i version. Why is that useful ? There a re someusage. For instance, the Dist::Zilla AutoPrereqs is confused by "use perl5i::2", and produce a requirement on "perl5i::2" instead of "perl5i". Other issues can be experienced in different cases. It also opens the possibility for global argument management. Also, I like this API :)
