### PR TITLE
Add 'no bareword::filehandles'

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -50,6 +50,7 @@ my $builder = MyBuild->new(
         'true::VERSION'       => '0.16',
         'Capture::Tiny'       => '0.06',
         'utf8::all'           => '0.002',
+        'bareword::filehandles' => '0.003',
     },
     build_requires => {
         'ExtUtils::CBuilder' => '0.26',

--- a/META.json
+++ b/META.json
@@ -72,6 +72,7 @@
             "autobox::dump" : "20090426",
             "autodie" : "1.999",
             "autovivification" : "0.06",
+            "bareword::filehandles" : "0.003",
             "indirect" : "0.22",
             "parent" : "0.221",
             "perl" : "v5.10.0",

--- a/META.yml
+++ b/META.yml
@@ -206,6 +206,7 @@ requires:
   autobox::dump: 20090426
   autodie: 1.999
   autovivification: 0.06
+  bareword::filehandles: 0.003
   indirect: 0.22
   parent: 0.221
   perl: v5.10.0

--- a/lib/perl5i/2.pm
+++ b/lib/perl5i/2.pm
@@ -30,6 +30,7 @@ use parent 'perl5i::2::autobox';
 use parent 'autovivification';
 use parent 'indirect';
 use parent 'utf8::all';
+use parent 'bareword::filehandles';
 
 ## no critic (Subroutines::RequireArgUnpacking)
 sub import {
@@ -67,6 +68,7 @@ sub import {
     perl5i::2::autobox::import($class);
     autovivification::unimport($class);
     indirect::unimport($class, ":fatal");
+    bareword::filehandles::unimport($class);
 
     utf8::all::import($class);
     (\&perl5i::latest::open)->alias($caller, 'open');

--- a/t/no-bareword-filehandles.t
+++ b/t/no-bareword-filehandles.t
@@ -1,0 +1,18 @@
+use Test::More tests => 4;
+
+open IN, '<', __FILE__;
+ok(IN, 'bareword filehandle opened OK');
+
+open my $in, '<', __FILE__;
+ok($in, 'lexical filehandle opened OK');
+
+use perl5i::latest;
+try {
+    open IN2, '<', __FILE__;
+}
+catch {
+    like($_, qr{\QCan't use string ("IN2") as a symbol ref while "strict refs" in use},
+        q{Can't use bareword filehandles with perl5i in scope});
+};
+open my $in2, '<', __FILE__;
+ok($in2, 'lexical filehandle opened OK');


### PR DESCRIPTION
This disallows the use of bareword filehandles:

``` perl
    open IN, '<', $file; #dies with:
        # Can't use string ("IN") as a symbol ref while "strict refs" in use
```

Partially fixes #175. `no multidimensional` causes `t/autovivification.t` to fail with "Can't use an undefined value as a HASH reference at t/autovivification.t line 10." and I'm not sure why.
