### PR TITLE
Use a proper version number to silence spurious warning

### DIFF
--- a/lib/perl5i/2/Meta/Instance.pm
+++ b/lib/perl5i/2/Meta/Instance.pm
@@ -1,6 +1,6 @@
 package perl5i::2::Meta::Instance;
 
-use v5.10;
+use v5.10.0;
 use strict;
 use warnings;
 


### PR DESCRIPTION
Fixes #174
