### PR TITLE
Mostly fix the fight between the open pragma and autodie.

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -49,7 +49,7 @@ my $builder = MyBuild->new(
         "Devel::Declare::MethodInstaller::Simple"       => '0.006007',
         'true::VERSION'       => '0.16',
         'Capture::Tiny'       => '0.06',
-        'utf8::all'           => '0.002',
+        'utf8::all'           => '0.004',
         'Carp::Fix::1_25'     => '1.000000',
     },
     build_requires => {

--- a/Changes
+++ b/Changes
@@ -1,4 +1,7 @@
 2.10.0
+  Bug Fixes
+  * Restore utf8 for newly opened filehandles.
+
   Test Fixes
   * Removed a use of Test::Exception, which we don't depend on.
 

--- a/lib/perl5i/2.pm
+++ b/lib/perl5i/2.pm
@@ -69,7 +69,7 @@ sub import {
     indirect::unimport($class, ":fatal");
 
     utf8::all::import($class);
-    (\&perl5i::latest::open)->alias($caller, 'open');
+    (\&open)->alias($caller, "open");
 
     # Export our gmtime() and localtime()
     (\&{$Latest .'::DateTime::dt_gmtime'})->alias($caller, 'gmtime');
@@ -113,6 +113,27 @@ sub perl5i_die {
 
     local $! = 255;
     return CORE::die($error);
+}
+
+
+# This function must be called open() because autodie will decide what to do
+# with the exception based on the name of the function.
+sub open(*;$@) { ## no critic (Subroutines::ProhibitSubroutinePrototypes)
+    my $ret;
+    if ( @_ == 1 ) {
+        $ret = open $_[0];
+    } elsif ( @_ == 2 ) {
+        $ret = open $_[0], $_[1];
+    } else {
+        $ret = open $_[0], $_[1], @_[2..$#_];
+    }
+
+    # Don't try to binmode an unopened filehandle
+    return $ret unless $ret;
+
+    my $h = (caller 1)[10];
+    binmode $_[0], ":encoding(utf8)" if $h->{perl5i};
+    return $ret;
 }
 
 

--- a/t/autodie.t
+++ b/t/autodie.t
@@ -1,7 +1,7 @@
 #!perl
 
 use perl5i::latest;
-use Test::More "no_plan";
+use Test::More;
 
 ok !eval { open my $fh, "hlaglaghlaghlagh"; 1 };
 
@@ -12,3 +12,17 @@ if( $^O eq 'MSWin32' ) {
 } else {
     ok !eval { system "haljlkjadlkjflajdf"; 1; };
 }
+
+note "open() message formatting"; {
+    ok !eval { open my $fh, "i_do_not_exist"; 1 };
+    is $@->file, __FILE__;
+    is $@->line, __LINE__ - 2;
+    unlike $@, qr/perl5i/, "open error should not mention perl5i";
+
+    TODO: {
+        local $TODO = 'open function from autodie exception';
+        is $@->function, "open";
+    }
+}
+
+done_testing;


### PR DESCRIPTION
utf8::all switched from using a wrapper around open to using the open pragma.
Unfortunately, autodie loses the open pragma.  This fixes most of the problem.
The only thing remaining is because autodie does not recognize our open() as
CORE::open() it formats the error message a little differently.  At this point
I'd rather see the problem fixed inside autodie than hack the bug further here.

I'm not entirely sure why its kosher to have a function named open() that
calls open() (which is autodie's open).  It was necessary to name our
function open() so that autodie produced a sensible error message.

In addition:
- Update utf8::all to the latest to avoid inconsistencies between our
  hacks and theirs

PS  This will fix the current failing tests and get CPAN working again.
