### PR TITLE
Add $scalar->path to turn make a Path::Tiny object from $scalar.

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -53,6 +53,7 @@ my $builder = MyBuild->new(
         'Carp::Fix::1_25'     => '1.000000',
         'Hash::StoredIterator' => '0.001',
         'Hash::FieldHash'     => '0.06',
+        'Path::Tiny'          => '0.15',
     },
     build_requires => {
         'ExtUtils::CBuilder' => '0.26',

--- a/lib/perl5i.pm
+++ b/lib/perl5i.pm
@@ -306,6 +306,16 @@ All of the methods provided by L<autobox::Core> are available from perl5i.
 
 in addition, perl5i adds some methods of its own.
 
+=head3 path
+
+    my $object = $path->path;
+
+Creates a L<Path::Tiny> $object for the given file or directory $path.
+
+    my $path = "/foo/bar/baz.txt"->path;
+    my $content = $path->slurp;
+
+
 =head3 center
 
     my $centered_string = $string->center($length);

--- a/lib/perl5i/2/SCALAR.pm
+++ b/lib/perl5i/2/SCALAR.pm
@@ -287,4 +287,15 @@ sub module2path {
     return join "/", @parts;
 }
 
+
+# On the first call, load Path::Tiny and replace our path() with
+# Path::Tiny::path() so we don't try to load it again.
+# Shaves about 1/6 off the call time.
+sub path {
+    require Path::Tiny;
+    no warnings 'redefine';
+    *path = \&Path::Tiny::path;
+    goto &Path::Tiny::path;
+}
+
 1;

--- a/t/path/base.t
+++ b/t/path/base.t
@@ -1,0 +1,18 @@
+#!/usr/bin/env perl
+
+# Basic testing of path() and Path::Tiny
+
+use perl5i::latest;
+use Test::Most;
+
+note "is Path::Tiny working?"; {
+    my $file = $0->path;
+    isa_ok $file, "Path::Tiny";
+
+    my $content = $file->slurp;
+    like $content, qr/slurp/;
+
+    ok $file->exists;
+}
+
+done_testing;


### PR DESCRIPTION
For #229 

This is a very basic implementation.  There's lots we can add to Path::Tiny which can come later.

The load time of Path::Tiny is up to 25% of perl5i, so we must load it
on demand.

I benchmarked the cost of "require Path::Tiny" every time and it
came out to be a significant difference for object construction.

The docs are very understated for what impact on the ease of
file manipulation this has.

Path::Tiny has some useful class methods.  cwd, rootdir, tempfile
and tempdir.  There's no way to access them through perl5i, you
have to use Path::Tiny directly.  This is less than ideal, but
ok for now.
