### PR TITLE
suppress "Smartmatch is experimental" warnings on 5.18+

### DIFF
--- a/lib/perl5i/0/ARRAY.pm
+++ b/lib/perl5i/0/ARRAY.pm
@@ -4,6 +4,7 @@ use 5.010;
 
 use strict;
 use warnings;
+no if $] >= 5.018000, warnings => 'experimental::smartmatch';
 
 sub ARRAY::first {
     my ( $array, $filter ) = @_;

--- a/lib/perl5i/1/ARRAY.pm
+++ b/lib/perl5i/1/ARRAY.pm
@@ -4,6 +4,7 @@ use 5.010;
 
 use strict;
 use warnings;
+no if $] >= 5.018000, warnings => 'experimental::smartmatch';
 
 use perl5i::1::autobox;
 

--- a/lib/perl5i/1/Meta/Instance.pm
+++ b/lib/perl5i/1/Meta/Instance.pm
@@ -2,6 +2,7 @@ package perl5i::1::Meta::Instance;
 
 use strict;
 use warnings;
+no if $] > 5.018000, warnings => 'experimental::smartmatch';
 
 require Scalar::Util;
 require overload;

--- a/lib/perl5i/2/ARRAY.pm
+++ b/lib/perl5i/2/ARRAY.pm
@@ -4,6 +4,7 @@ use 5.010;
 
 use strict;
 use warnings;
+no if $] >= 5.018000, warnings => 'experimental::smartmatch';
 
 # Don't accidentally turn carp/croak into methods.
 require Carp::Fix::1_25;

--- a/lib/perl5i/2/Meta/Instance.pm
+++ b/lib/perl5i/2/Meta/Instance.pm
@@ -5,6 +5,7 @@ package perl5i::2::Meta::Instance;
 use 5.010_000;
 use strict;
 use warnings;
+no if $] >= 5.018000, warnings => 'experimental::smartmatch';
 
 # Don't import anything that might be misinterpreted as a method
 require Scalar::Util;

--- a/lib/perl5i/2/equal.pm
+++ b/lib/perl5i/2/equal.pm
@@ -1,6 +1,8 @@
 package perl5i::2::equal;
 
 use strict;
+no if $] >= 5.018000, warnings => 'experimental::smartmatch';
+
 use perl5i::2::autobox;
 
 sub are_equal {


### PR DESCRIPTION
This suppresses perl 5.18's "Smartmatch is experimental" warning, which is actually fatal to several tests.  It should have no effect in perl versions pre-5.18.
