### PR TITLE
relaxed test for "Module doesnt exist" in t/require.t

### DIFF
--- a/t/require.t
+++ b/t/require.t
@@ -23,10 +23,13 @@ note "Module doesn't exist"; {
     local $!;
     local @INC = qw(no thing);
     ok !eval { "I::Sure::Dont::Exist"->require; };
-    like $@, qr[^Can't locate I/Sure/Dont/Exist\.pm in \@INC.*\(\@INC contains: no thing\) at ];
+    my $pat = q[^Can't locate I/Sure/Dont/Exist\.pm in \@INC];
+    $pat .= q[(?: \(you may need to install the I::Sure::Dont::Exist module\))?]; 
+    $pat .= sprintf(' \(@INC contains: no thing\) at %s line %d\.$',
+                    __FILE__, __LINE__-4);
+    like $@, qr/$pat/;
     ok !$!, "errno didn't leak out";
 }
-
 
 note "Invalid module name"; {
     ok !eval { "/tmp::LOL::PWNED"->require };


### PR DESCRIPTION
Perl 5.18 adds a "helpful" parenthetical to the error message for modules not found, so I relaxed the test by turning it into a regex match.
