### PR TITLE
Use IRC rather than Chat for IRC link

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -73,7 +73,7 @@ my $builder = MyBuild->new(
         resources => {
             repository  => 'http://github.com/evalEmpire/perl5i/tree/master',
             bugtracker  => 'http://github.com/evalEmpire/perl5i/issues',
-            Chat        => "irc://irc.perl.org/#perl5i",
+            IRC         => "irc://irc.perl.org/#perl5i",
         },
         no_index => {
             file  => [qw(


### PR DESCRIPTION
IRC is more commonly used by other modules, and is displayed on MetaCPAN.
