### PR TITLE
normalize version numbers and use App::RewriteVersion in tooling

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -2,8 +2,7 @@
 
 use strict;
 
-# Include 'lib' so it sees our perl5i::VERSION when version checking
-use lib 'inc', 'lib';
+use lib 'inc';
 use MyBuild;
 
 use 5.010;
@@ -12,7 +11,6 @@ my $builder = MyBuild->new(
     module_name => 'perl5i',
     license     => 'perl',
     dist_author => 'Michael G Schwern <schwern@pobox.com>',
-    dist_version => "v2.13.2",
 
     requires => {
         'perl'                    => '5.10.0',

--- a/admin/change_version
+++ b/admin/change_version
@@ -1,7 +1,8 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
+
+use App::RewriteVersion;
 
 my $version = shift;
 die "$0 <version>\n" unless $version;
-system qq[perl -i -pe 's{(dist_version \\s* => \\s*) \\S+ (.*)}{\$1"v$version",}x' Build.PL];
-system qq[perl -i -pe 's{v[.\\d_]+}{v$version}' lib/perl5i/VERSION.pm];
+App::RewriteVersion->new(verbose => 1)->rewrite_versions($version);
 

--- a/admin/new_major_version
+++ b/admin/new_major_version
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 $new_version = shift || die "$0 <new version>\n";
 $old_version = $new_version - 1;
@@ -13,7 +13,8 @@ run(qq[find lib/perl5i/$new_version -type f -print0 | xargs -0 $change_version])
 run("$change_version lib/perl5i/{Meta,VERSION,latest,$new_version}.pm lib/*.pm lib/*.pod");
 
 # Change the distribution version number to $new.0.0
-run(qq[perl -i -pe 's{v$old_version [.\\d]+}{v$new_version.0.0}x' lib/perl5i/VERSION.pm Build.PL]);
+use App::RewriteVersion;
+App::RewriteVersion->new(verbose => 1)->rewrite_versions("v${new_version}.0.0");
 
 sub run {
     my @cmd = @_;

--- a/lib/perl5i.pm
+++ b/lib/perl5i.pm
@@ -8,7 +8,7 @@ package perl5i;
 use strict;
 use parent 'perl5i::latest';
 
-use perl5i::VERSION; our $VERSION = perl5i::VERSION->VERSION;
+our $VERSION = 'v2.13.2';
 
 my $Latest = perl5i::VERSION->latest;
 

--- a/lib/perl5i/0.pm
+++ b/lib/perl5i/0.pm
@@ -19,7 +19,7 @@ use perl5i::0::Meta;
 use autobox;
 use Encode ();
 
-use perl5i::VERSION; our $VERSION = perl5i::VERSION->VERSION;
+our $VERSION = 'v2.13.2';
 
 our $Latest = 'perl5i::0';
 

--- a/lib/perl5i/1.pm
+++ b/lib/perl5i/1.pm
@@ -15,7 +15,7 @@ use perl5i::1::Meta;
 use Encode ();
 use perl5i::1::autobox;
 
-use perl5i::VERSION; our $VERSION = perl5i::VERSION->VERSION;
+our $VERSION = 'v2.13.2';
 
 our $Latest = 'perl5i::1';
 

--- a/lib/perl5i/2.pm
+++ b/lib/perl5i/2.pm
@@ -13,8 +13,9 @@ use Carp::Fix::1_25;
 use perl5i::2::autobox;
 use Import::Into;
 
-use perl5i::VERSION; our $VERSION = perl5i::VERSION->VERSION;
+our $VERSION = 'v2.13.2';
 
+use perl5i::VERSION;
 our $Latest = perl5i::VERSION->latest;
 
 my %Features = (

--- a/lib/perl5i/VERSION.pm
+++ b/lib/perl5i/VERSION.pm
@@ -5,7 +5,7 @@ package perl5i::VERSION;
 use strict;
 use warnings;
 
-use version 0.77; our $VERSION = qv("v2.13.2");
+our $VERSION = 'v2.13.2';
 
 sub latest { "perl5i::2" };     # LATEST HERE (for automated update)
 

--- a/lib/perl5i/latest.pm
+++ b/lib/perl5i/latest.pm
@@ -3,9 +3,10 @@ package perl5i::latest;
 use strict;
 use warnings;
 
-use perl5i::VERSION; our $VERSION = perl5i::VERSION->VERSION;
+our $VERSION = 'v2.13.2';
 
 my $Latest;
+use perl5i::VERSION;
 BEGIN { $Latest = perl5i::VERSION->latest; }
 
 use parent ($Latest);


### PR DESCRIPTION
Fixes #303

* dist_version doesn't need to be specified in Build.PL, Module::Build can retrieve it from dist_version_from (which will default to lib/perl5i.pm based on the module_name).
* the 'use version' and explicit version object construction isn't necessary on 5.10+ where version.pm is core. also, App::RewriteVersion can't rewrite those anyway
* App::RewriteVersion does *not* support underscore versions in tuples. This is by design, because these are pretty crazy and you would need to depend on version.pm 0.9915 to get consistent behavior for them. App::RewriteVersion can pass a 'is_trial' option to rewrite_versions, but that will only append a # TRIAL comment to the version declarations, assuming you will mark the release as a trial yourself. (you can do this by adding -TRIAL to the tarball name just before the file extension, and by setting a [release_status](https://metacpan.org/pod/distribution/Module-Build/lib/Module/Build/API.pod#release_status) other than stable.)
* Module::Build unfortunately has no built in way to specify App::RewriteVersion as a develop prereq, but the error message should hopefully make it apparent when it's needed.
* changed admin shebangs because my perl is not in /usr/bin :)