### PR TITLE
simplify no_index metadata and include later versions

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -89,17 +89,8 @@ my $builder = MyBuild->new(
             IRC         => "irc://irc.perl.org/#perl5i",
         },
         no_index => {
-            file  => [qw(
-                lib/perl5i/0/DateTime.pm
-                lib/perl5i/0/ARRAY.pm
-                lib/perl5i/0/DEFAULT.pm
-                lib/perl5i/0/HASH.pm
-                lib/perl5i/0/Meta.pm
-                lib/perl5i/0/Meta/Class.pm
-                lib/perl5i/0/Meta/Instance.pm
-                lib/perl5i/0/SCALAR.pm
-                lib/perl5i/VERSION.pm
-            )],
+            namespace  => [qw(perl5i::0 perl5i::1 perl5i::2)],
+            file       => [qw(lib/perl5i/VERSION.pm)],
         },
     },
 


### PR DESCRIPTION
I'm not sure if it was intended to add only the submodules of perl5i::0 to no_index, but the 'namespace' key is a simpler way to do this. Added the perl5i::1 and perl5i::2 namespaces as well. These will still allow those modules to be indexed but not any modules under that namespace. https://metacpan.org/pod/CPAN::Meta::Spec#no_index